### PR TITLE
make terminalbridge.h compilable as-is in objC

### DIFF
--- a/src/frontend/terminalbridge.h
+++ b/src/frontend/terminalbridge.h
@@ -2,8 +2,10 @@
 #define TERMINALBRIDGE_H
 
 #include <sys/ioctl.h>
+#include <sys/file.h>
+#include <stdio.h>
 
 int mosh_main(FILE *f_in, FILE *f_out, struct winsize *window_size,
-	      const char *ip, const char *port, const char *key, const char *predict_mode)
+	      const char *ip, const char *port, const char *key, const char *predict_mode);
 
 #endif


### PR DESCRIPTION
missing header for FILE, and a missing ; mean this won't work
